### PR TITLE
Remove whitespace from verification header

### DIFF
--- a/s3-auth-proxy.js
+++ b/s3-auth-proxy.js
@@ -30,7 +30,7 @@ var handle_request = function (client_request, client_response) {
           verificationSigner.headers['x-amz-date']
       )
 
-      if (givenClientAuthorization != correctClientAuthorization) {
+      if (givenClientAuthorization.replace(/\s/g,'') !== correctClientAuthorization.replace(/\s/g,'')) {
           console.error('incorrect authorization', givenClientAuthorization)
           client_response.writeHead(403)
           client_response.end()


### PR DESCRIPTION
Results in a more consistent connecting behavior when using different clients.

When using certain s3 clients (e.g. Cyberduck), the authorization headers sent are separated by ',' instead of ' ,', which makes the string match fail. This fix should account for that differing behavior and still leave the comparison unique.