### PR TITLE
Fix parsing bucket name if url contains query parameters

### DIFF
--- a/s3-auth-proxy.js
+++ b/s3-auth-proxy.js
@@ -41,7 +41,7 @@ var handle_request = function (client_request, client_response) {
             return
         }
 
-        const bucket = client_request.url.split("/")[1]
+        const bucket = client_request.url.split(/[/?]/)[1]
         if (
             bucket &&
             !allowedBuckets.includes(bucket) &&


### PR DESCRIPTION
This seems to be a problem with e.g. goofys.